### PR TITLE
Added PlaceholderTextColor setting

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ import {
 
 const RNSearchablePicker = ({
   placeholder,
+  placeholderTextColor,
   emptyMessage,
   defaultValue = "",
   data,
@@ -55,6 +56,7 @@ const RNSearchablePicker = ({
           value={inputValue}
           onChangeText={onChange}
           placeholder={placeholder}
+          placeholderTextColor={placeholderTextColor}
           style={{ flex: 1, ...inputStyles }}
         />
         <Touchable


### PR DESCRIPTION
I was using your package, and I noticed placeholder not showing, it's because we must define placeholderTextColor in TextInput it was added in the last version of react native.